### PR TITLE
Add 14APH8 model to Tested Devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ While this feature is exposed to Linux users, it is not the easiest thing to con
 #### Tested Devices
 
 * IdeaPad 5 Pro Gen 6 14'
+* IdeaPad 5 Pro Gen 8 14' [83AM001DCK](https://psref.lenovo.com/Detail/IdeaPad/IdeaPad_Pro_5_14APH8?M=83AM001DCK)
 
 
 


### PR DESCRIPTION
I did include a link to a specific model as Lenovo ships this version with and without discrete GPU and I have 120Hz 2.8K display, Ryzen 7 7840HS, 32GB of ram and an iGPU, so I think this is important.